### PR TITLE
XIVY-9832 Remove maven definitions which are part of product.json

### DIFF
--- a/market/basic-workflow-ui/meta.json
+++ b/market/basic-workflow-ui/meta.json
@@ -14,11 +14,6 @@
 			"groupId": "ch.ivyteam.ivy.project.wf",
 			"artifactId": "basic-workflow-ui-product",
 			"type": "zip"
-		},
-		{
-			"name": "Basic Workflow UI",
-			"groupId": "ch.ivyteam.ivy.project.wf",
-			"artifactId": "basic-workflow-ui"
 		}
 	]
 }

--- a/market/connector/a-trust/meta.json
+++ b/market/connector/a-trust/meta.json
@@ -16,19 +16,6 @@
             "groupId": "com.axonivy.connector.atrust",
             "artifactId": "a-trust-connector-product",
             "type": "zip"
-        },
-        {
-            "repoUrl": "https://maven.axonivy.com",
-            "name": "A-Trust",
-            "groupId": "com.axonivy.connector.atrust",
-            "artifactId": "a-trust-connector",
-            "makesSenseAsMavenDependency": true
-        },
-        {
-            "repoUrl": "https://maven.axonivy.com",
-            "name": "A-Trust Demo",
-            "groupId": "com.axonivy.connector.atrust",
-            "artifactId": "a-trust-connector-demo"
         }
     ]    
 }

--- a/market/connector/alfresco/meta.json
+++ b/market/connector/alfresco/meta.json
@@ -16,19 +16,6 @@
             "groupId": "com.axonivy.connector.alfresco",
             "artifactId": "alfresco-connector-product",
             "type": "zip"
-        },
-        {
-            "repoUrl": "https://maven.axonivy.com",
-            "name": "Alfresco ECM",
-            "groupId": "com.axonivy.connector.alfresco",
-            "artifactId": "alfresco-connector",
-            "makesSenseAsMavenDependency": true
-        },
-        {
-            "repoUrl": "https://maven.axonivy.com",
-            "name": "Alfresco Demo",
-            "groupId": "com.axonivy.connector.alfresco",
-            "artifactId": "alfresco-connector-demo"
         }
     ]    
 }

--- a/market/connector/amazon-comprehend/meta.json
+++ b/market/connector/amazon-comprehend/meta.json
@@ -16,19 +16,6 @@
             "groupId": "com.axonivy.connector.amazon.comprehend",
             "artifactId": "amazon-comprehend-connector-product",
             "type": "zip"
-        },
-        {
-            "repoUrl": "https://maven.axonivy.com",
-            "name": "Amazon Comprehend",
-            "groupId": "com.axonivy.connector.amazon.comprehend",
-            "artifactId": "amazon-comprehend-connector",
-            "makesSenseAsMavenDependency": true
-        },
-        {
-            "repoUrl": "https://maven.axonivy.com",
-            "name": "Amazon Comprehend Demo",
-            "groupId": "com.axonivy.connector.amazon.comprehend",
-            "artifactId": "amazon-comprehend-connector-demo"
         }
     ]    
 }

--- a/market/connector/amazon-lex/meta.json
+++ b/market/connector/amazon-lex/meta.json
@@ -16,19 +16,6 @@
             "groupId": "com.axonivy.connector.amazon.lex",
             "artifactId": "amazon-lex-connector-product",
             "type": "zip"
-        },
-        {
-            "repoUrl": "https://maven.axonivy.com",
-            "name": "Amazon Lex",
-            "groupId": "com.axonivy.connector.amazon.lex",
-            "artifactId": "amazon-lex-connector",
-            "makesSenseAsMavenDependency": true
-        },
-        {
-            "repoUrl": "https://maven.axonivy.com",
-            "name": "Amazon Lex Demo",
-            "groupId": "com.axonivy.connector.amazon.lex",
-            "artifactId": "amazon-lex-connector-demo"
         }
     ]    
 }

--- a/market/connector/currencyConverter/meta.json
+++ b/market/connector/currencyConverter/meta.json
@@ -16,19 +16,6 @@
 			"groupId": "com.axonivy.connector.currency",
 			"artifactId": "currency-converter-connector-product",
 			"type": "zip"
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "Currency Converter Connector",
-			"groupId": "com.axonivy.connector.currency",
-			"artifactId": "currency-converter-connector",
-			"makesSenseAsMavenDependency": true
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "Currency Converter Connector Demo",
-			"groupId": "com.axonivy.connector.currency",
-			"artifactId": "currency-converter-connector-demo"
 		}
 	]
 }

--- a/market/connector/docusign-connector/meta.json
+++ b/market/connector/docusign-connector/meta.json
@@ -16,19 +16,6 @@
 			"groupId": "com.axonivy.connector.docusign",
 			"artifactId": "docusign-connector-product",
 			"type": "zip"
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "DocuSign Connector",
-			"groupId": "com.axonivy.connector.docusign",
-			"artifactId": "docusign-connector",
-			"makesSenseAsMavenDependency": true
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "DocuSign Connector Demo",
-			"groupId": "com.axonivy.connector.docusign",
-			"artifactId": "docusign-connector-demo"
 		}
 	]	
 }

--- a/market/connector/docuware-connector/meta.json
+++ b/market/connector/docuware-connector/meta.json
@@ -16,19 +16,6 @@
 			"groupId": "com.axonivy.connector.docuware",
 			"artifactId": "docuware-connector-product",
 			"type": "zip"
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "DocuWare Connector",
-			"groupId": "com.axonivy.connector.docuware",
-			"artifactId": "docuware-connector",
-			"makesSenseAsMavenDependency": true
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "DocuWare Connector Demo",
-			"groupId": "com.axonivy.connector.docuware",
-			"artifactId": "docuware-connector-demo"
 		}
 	]	
 }

--- a/market/connector/excel-connector/meta.json
+++ b/market/connector/excel-connector/meta.json
@@ -16,19 +16,6 @@
 			"groupId": "com.axonivy.connector.excel",
 			"artifactId": "excel-connector-product",
 			"type": "zip"
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "Excel Connector",
-			"groupId": "com.axonivy.connector.excel",
-			"artifactId": "excel-connector",
-			"makesSenseAsMavenDependency": true
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "Excel Connector Demo",
-			"groupId": "com.axonivy.connector.excel",
-			"artifactId": "excel-connector-demo"
 		}
 	]	
 }

--- a/market/connector/genderize-io-connector/meta.json
+++ b/market/connector/genderize-io-connector/meta.json
@@ -16,19 +16,6 @@
 			"groupId": "com.axonivy.connector.genderize",
 			"artifactId": "genderize-io-connector-product",
 			"type": "zip"
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "Genderize.io API Connector",
-			"groupId": "com.axonivy.connector.genderize",
-			"artifactId": "genderize-io-connector",
-			"makesSenseAsMavenDependency": true
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "Genderize.io API Demo",
-			"groupId": "com.axonivy.connector.genderize",
-			"artifactId": "genderize-io-connector-demo"
 		}
 	]	
 }

--- a/market/connector/intellix-connector/meta.json
+++ b/market/connector/intellix-connector/meta.json
@@ -16,19 +16,6 @@
 			"groupId": "com.axonivy.connector.intellix",
 			"artifactId": "axonivy-intellix-product",
 			"type": "zip"
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "Intellix Connector",
-			"groupId": "com.axonivy.connector.intellix",
-			"artifactId": "axonivy-intellix-connector",
-			"makesSenseAsMavenDependency": true
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "Intellix Connector Demo",
-			"groupId": "com.axonivy.connector.intellix",
-			"artifactId": "axonivy-intellix-demo"
 		}
 	]	
 }

--- a/market/connector/jira/meta.json
+++ b/market/connector/jira/meta.json
@@ -21,19 +21,6 @@
 			"groupId": "com.axonivy.connector.jira",
 			"artifactId": "jira-connector-product",
 			"type": "zip"
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "Jira Connector",
-			"groupId": "com.axonivy.connector.jira",
-			"artifactId": "jira-connector",
-			"makesSenseAsMavenDependency": true
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "Jira Connector Demo",
-			"groupId": "com.axonivy.connector.jira",
-			"artifactId": "jira-connector-demo"
 		}
 	]	
 }

--- a/market/connector/ldap-connector/meta.json
+++ b/market/connector/ldap-connector/meta.json
@@ -16,19 +16,6 @@
 			"groupId": "com.axonivy.connector.ldap",
 			"artifactId": "ldap-connector-product",
 			"type": "zip"
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "Active Directory Connector",
-			"groupId": "com.axonivy.connector.ldap",
-			"artifactId": "ldap-connector",
-			"makesSenseAsMavenDependency": true
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "Active Directory Demo",
-			"groupId": "com.axonivy.connector.ldap",
-			"artifactId": "ldap-connector-demo"
 		}
 	]	
 }

--- a/market/connector/microsoft365/calendar/meta.json
+++ b/market/connector/microsoft365/calendar/meta.json
@@ -17,19 +17,6 @@
 			"groupId": "com.axonivy.connector.office365",
 			"artifactId": "msgraph-calendar-product",
 			"type": "zip"
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "Microsoft Graph Connector",
-			"groupId": "com.axonivy.connector.office365",
-			"artifactId": "msgraph-connector",
-			"makesSenseAsMavenDependency": true
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "Microsoft Graph Calendar Demo",
-			"groupId": "com.axonivy.connector.office365",
-			"artifactId": "msgraph-calendar-demo"
 		}
 	]	
 }

--- a/market/connector/microsoft365/mail/meta.json
+++ b/market/connector/microsoft365/mail/meta.json
@@ -17,19 +17,6 @@
 			"groupId": "com.axonivy.connector.office365",
 			"artifactId": "msgraph-mail-product",
 			"type": "zip"
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "Microsoft Graph Connector",
-			"groupId": "com.axonivy.connector.office365",
-			"artifactId": "msgraph-connector",
-			"makesSenseAsMavenDependency": true
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "Microsoft Graph Mail Demo",
-			"groupId": "com.axonivy.connector.office365",
-			"artifactId": "msgraph-mail-demo"
 		}
 	]	
 }

--- a/market/connector/microsoft365/msgraph/meta.json
+++ b/market/connector/microsoft365/msgraph/meta.json
@@ -17,31 +17,6 @@
 			"groupId": "com.axonivy.connector.office365",
 			"artifactId": "msgraph-connector-product",
 			"type": "zip"
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "Microsoft Graph Connector",
-			"groupId": "com.axonivy.connector.office365",
-			"artifactId": "msgraph-connector",
-			"makesSenseAsMavenDependency": true
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "Microsoft Graph ToDo Demo",
-			"groupId": "com.axonivy.connector.office365",
-			"artifactId": "msgraph-todo-demo"
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "Microsoft Graph Calendar Demo",
-			"groupId": "com.axonivy.connector.office365",
-			"artifactId": "msgraph-calendar-demo"
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "Microsoft Graph Mail Demo",
-			"groupId": "com.axonivy.connector.office365",
-			"artifactId": "msgraph-mail-demo"
 		}
 	]	
 }

--- a/market/connector/microsoft365/toDo/meta.json
+++ b/market/connector/microsoft365/toDo/meta.json
@@ -16,19 +16,6 @@
 			"groupId": "com.axonivy.connector.office365",
 			"artifactId": "msgraph-todo-product",
 			"type": "zip"
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "Microsoft Graph Connector",
-			"groupId": "com.axonivy.connector.office365",
-			"artifactId": "msgraph-connector",
-			"makesSenseAsMavenDependency": true
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "Microsoft Graph ToDo Demo",
-			"groupId": "com.axonivy.connector.office365",
-			"artifactId": "msgraph-todo-demo"
 		}
 	]	
 }

--- a/market/connector/sftp/meta.json
+++ b/market/connector/sftp/meta.json
@@ -16,19 +16,6 @@
             "groupId": "com.axonivy.connector.sftp",
             "artifactId": "sftp-connector-product",
             "type": "zip"
-        },
-        {
-            "repoUrl": "https://maven.axonivy.com",
-            "name": "SFTP Connector",
-            "groupId": "com.axonivy.connector.sftp",
-            "artifactId": "sftp-connector",
-            "makesSenseAsMavenDependency": true
-        },
-        {
-            "repoUrl": "https://maven.axonivy.com",
-            "name": "SFTP Demo",
-            "groupId": "com.axonivy.connector.sftp",
-            "artifactId": "sftp-connector-demo"
         }
     ]    
 }

--- a/market/connector/tel-search-connector/meta.json
+++ b/market/connector/tel-search-connector/meta.json
@@ -16,19 +16,6 @@
 			"groupId": "com.axonivy.connector.telsearch",
 			"artifactId": "tel-search-ch-connector-product",
 			"type": "zip"
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "tel.search.ch Connector",
-			"groupId": "com.axonivy.connector.telsearch",
-			"artifactId": "tel-search-ch-connector",
-			"makesSenseAsMavenDependency": true
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "tel.search.ch Connector Demo",
-			"groupId": "com.axonivy.connector.telsearch",
-			"artifactId": "tel-search-ch-connector-demo"
 		}
 	]
 }

--- a/market/connector/twitter/meta.json
+++ b/market/connector/twitter/meta.json
@@ -18,19 +18,6 @@
 			"groupId": "com.axonivy.connector.twitter",
 			"artifactId": "twitter-connector-product",
 			"type": "zip"
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "Currency Converter Connector",
-			"groupId": "com.axonivy.connector.twitter",
-			"artifactId": "twitter-connector",
-			"makesSenseAsMavenDependency": true
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "Currency Converter Connector Demo",
-			"groupId": "com.axonivy.connector.twitter",
-			"artifactId": "twitter-connector-demo"
 		}
 	]
 }

--- a/market/connector/ui-path-connector/meta.json
+++ b/market/connector/ui-path-connector/meta.json
@@ -16,19 +16,6 @@
 			"groupId": "com.axonivy.connector.uipath",
 			"artifactId": "ui-path-connector-product",
 			"type": "zip"
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "UiPath Connector",
-			"groupId": "com.axonivy.connector.uipath",
-			"artifactId": "ui-path-connector",
-			"makesSenseAsMavenDependency": true
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "UiPath Connector Demo",
-			"groupId": "com.axonivy.connector.uipath",
-			"artifactId": "ui-path-connector-demo"
 		}
 	]	
 }

--- a/market/demos/connectivity/meta.json
+++ b/market/demos/connectivity/meta.json
@@ -18,16 +18,6 @@
 			"groupId": "com.axonivy.demo",
 			"artifactId": "connectivity-demos-product",
 			"type": "zip"
-		},
-		{
-			"name": "Connectivity Demos",
-			"groupId": "com.axonivy.demo",
-			"artifactId": "connectivity-demos"
-		},
-		{
-			"name": "Connectivity Demos Test",
-			"groupId": "com.axonivy.demo",
-			"artifactId": "connectivity-demos-test"
 		}
 	]	
 }

--- a/market/demos/custom-mail/meta.json
+++ b/market/demos/custom-mail/meta.json
@@ -15,11 +15,6 @@
 			"groupId": "com.axonivy.demo.custom.mail",
 			"artifactId": "custom-mail-demo-product",
 			"type": "zip"
-		},
-		{
-			"name": "Custom Mail Demo",
-			"groupId": "com.axonivy.demo.custom.mail",
-			"artifactId": "custom-mail-demo"
 		}
 	]	
 }

--- a/market/demos/error-handling/meta.json
+++ b/market/demos/error-handling/meta.json
@@ -16,11 +16,6 @@
 			"groupId": "com.axonivy.demo",
 			"artifactId": "error-handling-demos-product",
 			"type": "zip"
-		},
-		{
-			"name": "Error Handling Demos",
-			"groupId": "com.axonivy.demo",
-			"artifactId": "error-handling-demos"
 		}
 	]	
 }

--- a/market/demos/html-dialog/meta.json
+++ b/market/demos/html-dialog/meta.json
@@ -16,16 +16,6 @@
 			"groupId": "com.axonivy.demo",
 			"artifactId": "html-dialog-demos-product",
 			"type": "zip"
-		},
-		{
-			"name": "Html Dialog Demos",
-			"groupId": "com.axonivy.demo",
-			"artifactId": "html-dialog-demos"
-		},
-		{
-			"name": "Html Dialog Demos Test",
-			"groupId": "com.axonivy.demo",
-			"artifactId": "html-dialog-demos-test"
 		}
 	]	
 }

--- a/market/demos/quick-start-tutorial/meta.json
+++ b/market/demos/quick-start-tutorial/meta.json
@@ -17,11 +17,6 @@
 			"groupId": "com.axonivy.demo",
 			"artifactId": "quick-start-tutorial-product",
 			"type": "zip"
-		},
-		{
-			"name": "Quick Start Tutorial",
-			"groupId": "com.axonivy.demo",
-			"artifactId": "quick-start-tutorial"
 		}
 	]	
 }

--- a/market/demos/rule-engine/meta.json
+++ b/market/demos/rule-engine/meta.json
@@ -16,16 +16,6 @@
 			"groupId": "com.axonivy.demo",
 			"artifactId": "rule-engine-demos-product",
 			"type": "zip"
-		},
-		{
-			"name": "Rule Engine Demos",
-			"groupId": "com.axonivy.demo",
-			"artifactId": "rule-engine-demos"
-		},
-		{
-			"name": "Rule Engine Demos Test",
-			"groupId": "com.axonivy.demo",
-			"artifactId": "rule-engine-demos-test"
 		}
 	]	
 }

--- a/market/demos/workflow/meta.json
+++ b/market/demos/workflow/meta.json
@@ -16,16 +16,6 @@
 			"groupId": "com.axonivy.demo",
 			"artifactId": "workflow-demos-product",
 			"type": "zip"
-		},
-		{
-			"name": "Workflow Demos",
-			"groupId": "com.axonivy.demo",
-			"artifactId": "workflow-demos"
-		},
-		{
-			"name": "Workflow Demos Test",
-			"groupId": "com.axonivy.demo",
-			"artifactId": "workflow-demos-test"
 		}
 	]	
 }

--- a/market/doc-factory/meta.json
+++ b/market/doc-factory/meta.json
@@ -17,17 +17,6 @@
 			"type": "zip"
 		},
 		{
-			"name": "DocFactory",
-			"groupId": "com.axonivy.utils.docfactory",
-			"artifactId": "doc-factory",
-			"makesSenseAsMavenDependency": true
-		},
-		{
-			"name": "DocFactory Demo",
-			"groupId": "com.axonivy.utils.docfactory",
-			"artifactId": "doc-factory-demos"
-		},
-		{
 			"name": "DocFactory Documentation",
 			"groupId": "com.axonivy.utils.docfactory",
 			"artifactId": "doc-factory-doc",

--- a/market/utils/google-maps-connector/meta.json
+++ b/market/utils/google-maps-connector/meta.json
@@ -15,19 +15,6 @@
 			"groupId": "com.axonivy.connector.google.maps",
 			"artifactId": "google-maps-connector-product",
 			"type": "zip"
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "Google Maps Connector",
-			"groupId": "com.axonivy.connector.google.maps",
-			"artifactId": "google-maps-connector",
-			"makesSenseAsMavenDependency": true
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "Google Maps Connector Demo",
-			"groupId": "com.axonivy.connector.google.maps",
-			"artifactId": "google-maps-connector-demo"
 		}
-	]	
+	]
 }

--- a/market/utils/html-dialog-utils/meta.json
+++ b/market/utils/html-dialog-utils/meta.json
@@ -16,19 +16,6 @@
 			"groupId": "com.axonivy.utils.htmldialog",
 			"artifactId": "html-dialog-utils-product",
 			"type": "zip"
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "HTML Dialog Utils",
-			"groupId": "com.axonivy.utils.htmldialog",
-			"artifactId": "html-dialog-utils",
-			"makesSenseAsMavenDependency": true
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "HTML Dialog Utils Demo",
-			"groupId": "com.axonivy.utils.htmldialog",
-			"artifactId": "html-dialog-utils-demo"
 		}
-	]	
+	]
 }

--- a/market/utils/persistence-utils/meta.json
+++ b/market/utils/persistence-utils/meta.json
@@ -16,19 +16,6 @@
 			"groupId": "com.axonivy.utils.persistence",
 			"artifactId": "persistence-utils-product",
 			"type": "zip"
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "Persistence Utils",
-			"groupId": "com.axonivy.utils.persistence",
-			"artifactId": "persistence-utils",
-			"makesSenseAsMavenDependency": true
-		},
-		{
-			"repoUrl": "https://maven.axonivy.com",
-			"name": "Persistence Utils Demo",
-			"groupId": "com.axonivy.utils.persistence",
-			"artifactId": "persistence-utils-demo"
 		}
 	]	
 }


### PR DESCRIPTION
It's only needed to define the product maven artifact. Other artifacts are depending on the version and can change over time.

There are artifacts which are not part of product json:
- documentation
- additional jars which we do not have a installer (dmn decision table, visual vm plugin)

These you still need to define here.