### PR TITLE
add props

### DIFF
--- a/market-test/src/main/java/com/axonivy/market/MarketModule.java
+++ b/market-test/src/main/java/com/axonivy/market/MarketModule.java
@@ -5,7 +5,7 @@ import io.github.axonivy.json.schema.ExpressiveSchemaModule;
 public class MarketModule extends ExpressiveSchemaModule {
 
   public MarketModule() {
-    super(); // wrapper; that works in pom invocatoin
+    super(ExpressiveSchemaOption.USE_ADDITIONAL_PROPERTIES_ANNOTATION); // wrapper; that works in pom invocatoin
   }
 
 }


### PR DESCRIPTION
strictly validate the meta.json files, for not containing unknown properties or invalid values.
this brings the build automatically to fail ... as we see here by example, if the format is not valid.