### PR TITLE
MARP-977-A-trust-refactoring

### DIFF
--- a/market/connector/a-trust/meta.json
+++ b/market/connector/a-trust/meta.json
@@ -29,7 +29,7 @@
   "statusBadgeUrl": "https://github.com/axonivy-market/a-trust-connector/actions/workflows/ci.yml/badge.svg",
   "language": "English",
   "industry": "Cross-Industry",
-  "listed": false,
+  "listed": true,
   "tags": ["e-signature"],
   "mavenArtifacts": [
     {


### PR DESCRIPTION
Dear @ivy-sgi 
The new version of ATrust has been released https://github.com/axonivy-market/a-trust-connector/packages/845482?version=10.0.22

Can we enable this connector again on the Landing page?

FYI @phhung-axonivy 